### PR TITLE
Remove the pid file when a service stop is called

### DIFF
--- a/templates/default/remote_syslog2.erb
+++ b/templates/default/remote_syslog2.erb
@@ -51,6 +51,7 @@ stop(){
       kill `cat $pid_file`
       RETVAL=$?
       echo
+      [ $RETVAL -eq 0 ] && [ -e "$pid_file" ] && rm -f $pid_file
       return $RETVAL
     else
       echo "$pid_file not found"


### PR DESCRIPTION
It wasn't deleting the pid file when stop was called, so the status was returning incorrectly
