### PR TITLE
Fix port needing to be integer

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,6 @@ gem 'stove'
 
 gem 'test-kitchen'
 gem 'kitchen-vagrant'
+
+gem 'chefspec'
+gem 'foodcritic'

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+.kitchen
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jeff.way@me.com'
 license          'Apache 2.0'
 description      'Installs/Configures remote_syslog2'
 long_description 'Installs/Configures remote_syslog2'
-version          '0.2.3'
+version          '0.2.4'
 
 supports 'ubuntu'
 

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,5 +1,12 @@
+include_recipe 'remote_syslog2::service'
+
+config = node['remote_syslog2']['config'].to_hash
+if config.key?('destination') && config['destination'].key?('port') && config['destination']['port']
+  config['destination']['port'] = config['destination']['port'].to_i
+end
+
 file node['remote_syslog2']['config_file'] do
-  content node['remote_syslog2']['config'].to_hash.to_yaml
+  content config.to_yaml
   mode '0644'
   notifies :restart, 'service[remote_syslog2]', :delayed
 end

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -1,0 +1,40 @@
+describe 'remote_syslog2::configure' do
+  context 'default run' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.automatic['hostname'] = 'foo.example.com'
+      end.converge(described_recipe)
+    end
+
+    it 'should include the service recipe so that it can restart the service' do
+      expect(chef_run).to include_recipe('remote_syslog2::service')
+    end
+
+    it 'should write out the configuration file' do
+      expect(chef_run).to render_file('/etc/remote_syslog2.yml').with_content(<<-YAML
+---
+files: []
+exclude_files: []
+exclude_patterns: []
+hostname: foo.example.com
+destination:
+  host: logs.papertrailapp.com
+  port: 12345
+YAML
+      )
+    end
+  end
+
+  context 'port is misconfigured to be a string' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.automatic['hostname'] = 'foo.example.com'
+        node.set['remote_syslog2']['config']['destination']['port'] = '514'
+      end.converge(described_recipe)
+    end
+
+    it 'should write out configuration with the port as an integer' do
+      expect(chef_run).to render_file('/etc/remote_syslog2.yml').with_content('port: 514')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/berkshelf'


### PR DESCRIPTION
Hi,

Thank you for the cookbook - it's proved very useful in getting going with v2 of remote_syslog!

We encountered an issue with our port being defined as a string (in an encrypted data bag but not sure that is relevant).

When configured with a string port and the `protocol: tls` option, remote_syslog2 refuses to start. Upon investigating (starting with the `-D` flag), we found that it ignores the port and tries to connect to port 514 over TLS.

Rather than change our instance of the misconfiguration, I thought I'd help make the cookbook more fault-tolerant.
I've added specs using ChefSpec ( https://sethvargo.github.io/chefspec/ ) and Foodcritic ( http://www.foodcritic.io/ ) has no complaints.

I'll raise the issue with the remote_syslog2 repo as well.

Thanks!
Kieren
