### PR TITLE
Fix generated config file on Chef 11.14.

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,5 +1,9 @@
 file node['remote_syslog2']['config_file'] do
-  content node['remote_syslog2']['config'].to_hash.to_yaml
+  # Using JSON.parse(x.to_json) to convert Chef::Node::ImmutableArray and
+  # Chef::Node::ImmutableMash to plain Ruby array and hash.
+  # https://tickets.opscode.com/browse/CHEF-3953
+  content JSON.parse(node['remote_syslog2']['config'].to_json).to_yaml
+
   mode '0644'
   notifies :restart, 'service[remote_syslog2]', :delayed
 end


### PR DESCRIPTION
The config file generated looks like this on chef 11.14 and remote_syslog2 can't understand it:

``` yaml
    files: !ruby/array:Chef::Node::ImmutableArray
    - /foo/bar
    exclude_files: !ruby/array:Chef::Node::ImmutableArray []
    exclude_patterns: !ruby/array:Chef::Node::ImmutableArray []
    hostname: foo.com
    destination: !ruby/hash:Chef::Node::ImmutableMash
      host: bar.com
      port: 12345
      protocol: tls
```

The fix is a workaround, converting the Chef hash to JSON and parsing it back so it becomes plain Ruby arrays and hashes.
