### PR TITLE
Allow configuration of command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ node['remote_syslog2']['config'] = {
 
 Since this is rendered directly to YAML, you can theoretically configure any value which is normally configurable. For more information please reference the [remote_syslog2 examples](https://github.com/papertrail/remote_syslog2/tree/master/examples)
 
+Additional remote_syslog2 command line settings can be specfified in the extra_options attribute
+
+```ruby
+node['remote_syslog2']['extra_options'] = '--facility=local6'
+```
+
 **Note that for the sake of clarity this cookbook saves the config file to /etc/remote_syslog2.yml rather than /etc/log_files.yml by default**
 
 Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,7 @@ default['remote_syslog2']['config'] = {
 
 # These attributes probably shouldn't be changed unless they specifically need to be
 default['remote_syslog2']['config_file'] = '/etc/remote_syslog2.yml'
+default['remote_syslog2']['extra_options'] = ''
 default['remote_syslog2']['pid_dir'] = '/var/run'
 default['remote_syslog2']['install']['download_file'] = 'https://github.com/papertrail/remote_syslog2/releases/download/v0.13/remote_syslog_linux_386.tar.gz'
 default['remote_syslog2']['install']['download_path'] = '/tmp/remote_syslog.tar.gz'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jeff.way@me.com'
 license          'Apache 2.0'
 description      'Installs/Configures remote_syslog2'
 long_description 'Installs/Configures remote_syslog2'
-version          '0.2.3'
+version          '0.2.4'
 
 supports 'ubuntu'
 

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -1,11 +1,12 @@
-service 'remote_syslog2' do
-  supports restart: true, status: true
-  action [:start, :enable]
-  end
-
 template '/etc/init.d/remote_syslog2' do
   source 'remote_syslog2.erb'
   mode '0755'
   notifies :restart, 'service[remote_syslog2]', :delayed
 end
+
+service 'remote_syslog2' do
+  supports restart: true, status: true
+  action [:start, :enable]
+end
+
 

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -1,9 +1,11 @@
-template '/etc/init.d/remote_syslog2' do
-  source 'remote_syslog2.erb'
-  mode '0755'
-end
-
 service 'remote_syslog2' do
   supports restart: true, status: true
   action [:start, :enable]
+  end
+
+template '/etc/init.d/remote_syslog2' do
+  source 'remote_syslog2.erb'
+  mode '0755'
+  notifies :restart, 'service[remote_syslog2]', :delayed
 end
+

--- a/templates/default/remote_syslog2.erb
+++ b/templates/default/remote_syslog2.erb
@@ -23,7 +23,7 @@ prog="<%= node['remote_syslog2']['install']['bin'] %>"
 config="<%= node['remote_syslog2']['config_file'] %>"
 pid_dir="<%= node['remote_syslog2']['pid_dir'] %>"
 
-EXTRAOPTIONS=""
+EXTRAOPTIONS="<%= node['remote_syslog2']['extra_options'] %>"
 
 pid_file="$pid_dir/$prog.pid"
 


### PR DESCRIPTION
Some remote_syslog2 configuration settings need to be passed over the command line.
This change support setting these via chef attributes.
