### PR TITLE
remote_syslog2 needs updating to 0.14+ to continue to work

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,7 +13,7 @@ default['remote_syslog2']['config'] = {
 # These attributes probably shouldn't be changed unless they specifically need to be
 default['remote_syslog2']['config_file'] = '/etc/remote_syslog2.yml'
 default['remote_syslog2']['pid_dir'] = '/var/run'
-default['remote_syslog2']['install']['download_file'] = 'https://github.com/papertrail/remote_syslog2/releases/download/v0.17/remote_syslog_linux_386.tar.gz'
+default['remote_syslog2']['install']['download_file'] = 'https://github.com/papertrail/remote_syslog2/releases/download/v0.17/remote_syslog_linux_i386.tar.gz'
 default['remote_syslog2']['install']['download_path'] = '/tmp/remote_syslog.tar.gz'
 default['remote_syslog2']['install']['extract_path'] = '/tmp'
 default['remote_syslog2']['install']['extracted_path'] = '/tmp/remote_syslog'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,7 +13,7 @@ default['remote_syslog2']['config'] = {
 # These attributes probably shouldn't be changed unless they specifically need to be
 default['remote_syslog2']['config_file'] = '/etc/remote_syslog2.yml'
 default['remote_syslog2']['pid_dir'] = '/var/run'
-default['remote_syslog2']['install']['download_file'] = 'https://github.com/papertrail/remote_syslog2/releases/download/v0.13/remote_syslog_linux_386.tar.gz'
+default['remote_syslog2']['install']['download_file'] = 'https://github.com/papertrail/remote_syslog2/releases/download/v0.17/remote_syslog_linux_386.tar.gz'
 default['remote_syslog2']['install']['download_path'] = '/tmp/remote_syslog.tar.gz'
 default['remote_syslog2']['install']['extract_path'] = '/tmp'
 default['remote_syslog2']['install']['extracted_path'] = '/tmp/remote_syslog'


### PR DESCRIPTION
http://blog.papertrailapp.com/april-14-new-sha2-tls-certificate-for-log-destinations/

```
On April 14, Papertrail deployed a new SHA-2 certificate, discovered that older versions of remote_syslog2 (0.13 and prior) did not accept the certificate, and reverted to the prior SHA-1 certificate.
...
The certificate will be deployed permanently on ​*Wednesday, May 4​*, 2016.
```

There is now 0.17 released as of 16th Feb
